### PR TITLE
Spelling of "without"

### DIFF
--- a/Examples/Quick print/main.cpy
+++ b/Examples/Quick print/main.cpy
@@ -10,7 +10,7 @@ int main()
 	! a b str "Second string"
 	!
 	
-	!! "!! is a quick print withought ending the line..."
+	!! "!! is a quick print without ending the line..."
 	! " Ending the line in the following command exemplified!"
 	
 	! "Following line is produced by command: ?? a b str"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ To compile cpy files use the created executable targeting the main file of the r
 	cpy main.cpy -flags
 
 ```
-CPY is a (Pre)Compiler of .cpy files, those are basically C++ withought redundancy.
+CPY is a (Pre)Compiler of .cpy files, those are basically C++ without redundancy.
 	Curly brackets are implied from identation
 	Semicolons are implied from line breaks (lines must be marked to continue, not to break)
 	Headers are interpreted from the sources and includes


### PR DESCRIPTION
Originally, it was spelled as "withought", but that is incorrect.

This pull request proposes a better spelling.